### PR TITLE
CodeLens → Document Links

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kirbysnippetopener",
   "displayName": "Kirby Snippet Opener",
   "description": "simplifies the process of navigating and managing snippet templates in Kirby CMS projects",
-  "version": "0.0.2",
+  "version": "0.1.2",
   "engines": {
     "vscode": "^1.94.0"
   },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kirbysnippetopener",
   "displayName": "Kirby Snippet Opener",
   "description": "simplifies the process of navigating and managing snippet templates in Kirby CMS projects",
-  "version": "0.1.1",
+  "version": "0.0.2",
   "engines": {
     "vscode": "^1.94.0"
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 import * as fs from "fs";
 import * as path from "path";
+
 /**
  * Activates the extension.
  *
@@ -11,51 +12,55 @@ import * as path from "path";
  * constructs the full path to the snippet file, and attempts to open it in the editor. If the file
  * cannot be found, an error message is displayed.
  *
- * Additionally, this function registers a CodeLens provider for the extension.
+ * Additionally, this function registers a Document Link provider for the extension.
  */
 export function activate(context: vscode.ExtensionContext) {
-  createSnippetFromSelection(context);
-  openSnippet(context);
-
-  // CodeLens-Provider registrieren
-  registerSnippetCodeLensProvider();
+  const disposables = [
+    registerOpenSnippetCommand(),
+    registerCreateSnippetFromSelectionCommand(),
+    registerSnippetDocumentLinkProvider()
+  ];
+  
+  context.subscriptions.push(...disposables);
 }
 
-export const openSnippet = (context: vscode.ExtensionContext) => {
-  const openSnippet = vscode.commands.registerCommand(
+/**
+ * Registers the command to open a snippet file.
+ * 
+ * @returns {vscode.Disposable} The disposable for the registered command.
+ */
+function registerOpenSnippetCommand(): vscode.Disposable {
+  return vscode.commands.registerCommand(
     "kirbysnippetopener.openSnippet",
     async (snippetName: string) => {
-      // Lese den Pfad aus den Einstellungen
-      const snippetPathConfig = vscode.workspace
-        .getConfiguration("kirbysnippetopener")
-        .get<string>("snippetPath");
-      const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+      // Get the URI for the snippet file
+      const snippetUri = getSnippetUri(snippetName);
+      if (!snippetUri) {
+        return;
+      }
 
-      if (workspaceFolder && snippetPathConfig) {
-        const snippetPath = vscode.Uri.joinPath(
-          workspaceFolder.uri,
-          snippetPathConfig,
-          `${snippetName}.php`
+      try {
+        const doc = await vscode.workspace.openTextDocument(snippetUri);
+        await vscode.window.showTextDocument(doc);
+      } catch (error) {
+        vscode.window.showErrorMessage(
+          `Snippet ${snippetName}.php konnte nicht gefunden werden.`
         );
-        try {
-          const doc = await vscode.workspace.openTextDocument(snippetPath);
-          vscode.window.showTextDocument(doc);
-        } catch (error) {
-          vscode.window.showErrorMessage(
-            `Snippet ${snippetName}.php konnte nicht gefunden werden.`
-          );
-        }
       }
     }
   );
+}
 
-  context.subscriptions.push(openSnippet);
-};
-
-export const createSnippetFromSelection = (
-  context: vscode.ExtensionContext
-) => {
-  const createSnippetFromSelection = vscode.commands.registerCommand(
+/**
+ * Registers the command to create a snippet from selected text.
+ * 
+ * This command allows users to select text in the editor, create a new snippet file
+ * with that content, and replace the selection with a snippet() function call.
+ * 
+ * @returns {vscode.Disposable} The disposable for the registered command.
+ */
+function registerCreateSnippetFromSelectionCommand(): vscode.Disposable {
+  return vscode.commands.registerCommand(
     "kirbysnippetopener.createSnippetFromSelection",
     async () => {
       // Get the active editor and selected text
@@ -65,115 +70,220 @@ export const createSnippetFromSelection = (
         return;
       }
 
-      const selection = editor.selection;
-      const selectedText = editor.document.getText(selection);
+      const selectedText = editor.document.getText(editor.selection);
       if (!selectedText) {
         vscode.window.showErrorMessage("No text selected.");
         return;
       }
 
       // Prompt the user to enter a file path for the snippet
-      const snippetPath = await vscode.window.showInputBox({
-        prompt:
-          "Enter the file path for the new snippet without suffix (e.g., components/card)",
-        placeHolder: "components/card",
-      });
+      const snippetPath = await promptForSnippetPath();
       if (!snippetPath) {
-        vscode.window.showErrorMessage("No file path entered.");
         return;
       }
 
-      const snippetConfigPath = vscode.workspace
-        .getConfiguration("kirbysnippetopener")
-        .get<string>("snippetPath");
-
-      if (!snippetConfigPath) {
-        vscode.window.showErrorMessage(
-          "You must set a snippet path in Vscode-Configuration."
-        );
-        return;
-      }
-
-      // Construct the full file path
-      const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
-      if (!workspaceFolder) {
-        vscode.window.showErrorMessage("No workspace folder found.");
-        return;
-      }
-
-      const fullPath = path.join(
-        workspaceFolder.uri.fsPath,
-        snippetConfigPath,
-        `${snippetPath}.php`
-      );
-
-      // Write the selected text to the new snippet file
-      try {
-        fs.mkdirSync(path.dirname(fullPath), { recursive: true });
-        fs.writeFileSync(fullPath, selectedText, "utf8");
-        vscode.window.showInformationMessage(
-          `Snippet created at ${snippetPath}`
-        );
-
-        // Replace the selected text with the snippet() function call
-        await editor.edit((editBuilder) => {
-          const snippetCall = `snippet('${snippetPath
-            .replace(/^snippets\//, "")
-            .replace(/\.php$/, "")}')`;
-          editBuilder.replace(selection, snippetCall);
-        });
-      } catch (error: any) {
-        vscode.window.showErrorMessage(
-          `Error creating snippet: ${error.message}`
-        );
+      // Create the snippet file and replace selection if successful
+      const success = await createSnippetFile(snippetPath, selectedText);
+      if (success) {
+        await replaceSelectionWithSnippetCall(editor, snippetPath);
       }
     }
   );
-
-  context.subscriptions.push(createSnippetFromSelection);
-};
+}
 
 /**
- * Registers a CodeLens provider for PHP files that detects snippets and provides
- * a command to open them.
+ * Registers a Document Link provider for PHP files that detects snippets and makes
+ * their paths clickable.
  *
  * This function uses a regular expression to find snippets in the document text,
- * creates a range for each match, and associates a CodeLens with a command to
- * open the snippet.
+ * creates a range for each snippet name, and associates a Document Link with the
+ * corresponding snippet file.
  *
- * @returns {void}
+ * @returns {vscode.Disposable} The disposable for the registered provider.
  */
-export function registerSnippetCodeLensProvider() {
-  vscode.languages.registerCodeLensProvider("php", {
-    provideCodeLenses(document) {
-      const codeLenses: vscode.CodeLens[] = [];
-      const regex = snippetRegex();
+function registerSnippetDocumentLinkProvider(): vscode.Disposable {
+  return vscode.languages.registerDocumentLinkProvider("php", {
+    provideDocumentLinks(document) {
+      const links: vscode.DocumentLink[] = [];
+      const text = document.getText();
+      const regex = getSnippetRegex();
       let match;
-      while ((match = regex.exec(document.getText())) !== null) {
-        const snippetName = match[1];
-        const range = new vscode.Range(
-          document.positionAt(match.index),
-          document.positionAt(match.index + match[0].length)
-        );
-
-        const command: vscode.Command = {
-          title: "Open Snippet",
-          command: "kirbysnippetopener.openSnippet",
-          arguments: [snippetName],
-        };
-        codeLenses.push(new vscode.CodeLens(range, command));
+      
+      while ((match = regex.exec(text)) !== null) {
+        const snippetName = match[2];
+        const link = createDocumentLink(document, match, snippetName);
+        if (link) {
+          links.push(link);
+        }
       }
-      return codeLenses;
-    },
+      
+      return links;
+    }
+  });
+}
+
+/**
+ * Creates a document link for a snippet match.
+ * 
+ * @param document - The text document containing the snippet call.
+ * @param match - The regex match result for the snippet call.
+ * @param snippetName - The name of the snippet to link to.
+ * @returns {vscode.DocumentLink | null} The document link or null if URI cannot be created.
+ */
+function createDocumentLink(
+  document: vscode.TextDocument, 
+  match: RegExpExecArray, 
+  snippetName: string
+): vscode.DocumentLink | null {
+  const snippetUri = getSnippetUri(snippetName);
+  if (!snippetUri) {
+    return null;
+  }
+
+  const range = getSnippetNameRange(document, match);
+  const link = new vscode.DocumentLink(range, snippetUri);
+  link.tooltip = `Open snippet: ${snippetName}.php`;
+  
+  return link;
+}
+
+/**
+ * Gets the range of the snippet name within the document (excluding quotes).
+ * 
+ * @param document - The text document.
+ * @param match - The regex match result.
+ * @returns {vscode.Range} The range of the snippet name.
+ */
+function getSnippetNameRange(document: vscode.TextDocument, match: RegExpExecArray): vscode.Range {
+  const quoteChar = match[1];
+  const snippetName = match[2];
+  const matchStart = match.index;
+  
+  // Find the exact position of the snippet name (excluding quotes)
+  const snippetNameStartInMatch = match[0].indexOf(quoteChar) + 1;
+  const snippetNameStart = document.positionAt(matchStart + snippetNameStartInMatch);
+  const snippetNameEnd = document.positionAt(matchStart + snippetNameStartInMatch + snippetName.length);
+  
+  return new vscode.Range(snippetNameStart, snippetNameEnd);
+}
+
+/**
+ * Gets the URI for a snippet file based on the snippet name and configuration.
+ * 
+ * @param snippetName - The name of the snippet.
+ * @returns {vscode.Uri | null} The URI of the snippet file or null if not available.
+ */
+function getSnippetUri(snippetName: string): vscode.Uri | null {
+  const config = getExtensionConfig();
+  const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+  
+  if (!workspaceFolder || !config.snippetPath) {
+    return null;
+  }
+  
+  return vscode.Uri.joinPath(
+    workspaceFolder.uri,
+    config.snippetPath,
+    `${snippetName}.php`
+  );
+}
+
+/**
+ * Gets the extension configuration settings.
+ * 
+ * @returns {object} Configuration object with snippetPath property.
+ */
+function getExtensionConfig() {
+  const config = vscode.workspace.getConfiguration("kirbysnippetopener");
+  return {
+    snippetPath: config.get<string>("snippetPath")
+  };
+}
+
+/**
+ * Prompts the user to enter a snippet path.
+ * 
+ * @returns {Promise<string | undefined>} The entered snippet path or undefined if cancelled.
+ */
+async function promptForSnippetPath(): Promise<string | undefined> {
+  return await vscode.window.showInputBox({
+    prompt: "Enter the file path for the new snippet without suffix (e.g., components/card)",
+    placeHolder: "components/card",
+  });
+}
+
+/**
+ * Creates a snippet file with the given content.
+ * 
+ * @param snippetPath - The relative path for the snippet file.
+ * @param content - The content to write to the snippet file.
+ * @returns {Promise<boolean>} True if the file was created successfully, false otherwise.
+ */
+async function createSnippetFile(snippetPath: string, content: string): Promise<boolean> {
+  const config = getExtensionConfig();
+  const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+  
+  if (!config.snippetPath) {
+    vscode.window.showErrorMessage("You must set a snippet path in VS Code configuration.");
+    return false;
+  }
+  
+  if (!workspaceFolder) {
+    vscode.window.showErrorMessage("No workspace folder found.");
+    return false;
+  }
+
+  // Construct the full file path
+  const fullPath = path.join(
+    workspaceFolder.uri.fsPath,
+    config.snippetPath,
+    `${snippetPath}.php`
+  );
+
+  // Write the selected text to the new snippet file
+  try {
+    fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+    fs.writeFileSync(fullPath, content, "utf8");
+    vscode.window.showInformationMessage(`Snippet created at ${snippetPath}`);
+    return true;
+  } catch (error: any) {
+    vscode.window.showErrorMessage(`Error creating snippet: ${error.message}`);
+    return false;
+  }
+}
+
+/**
+ * Replaces the current selection with a snippet function call.
+ * 
+ * @param editor - The text editor containing the selection.
+ * @param snippetPath - The path of the created snippet.
+ */
+async function replaceSelectionWithSnippetCall(
+  editor: vscode.TextEditor, 
+  snippetPath: string
+): Promise<void> {
+  // Clean the path by removing common prefixes and suffixes
+  const cleanPath = snippetPath
+    .replace(/^snippets\//, "")
+    .replace(/\.php$/, "");
+  
+  const snippetCall = `snippet('${cleanPath}')`;
+  
+  // Replace the selected text with the snippet() function call
+  await editor.edit((editBuilder) => {
+    editBuilder.replace(editor.selection, snippetCall);
   });
 }
 
 /**
  * Returns a regular expression that matches the pattern `snippet('...')` or `snippet("...")`.
- * The pattern captures the content within the parentheses and quotes.
+ * The pattern captures the quote character and the content within the quotes.
  *
  * @returns {RegExp} A regular expression to match snippet patterns.
  */
-export function snippetRegex() {
-  return /snippet\(\s*['"]([^'"]+)['"][\s\S]*?\)/g;
+function getSnippetRegex(): RegExp {
+  return /snippet\(\s*(['"])([^'"]+)\1[\s\S]*?\)/g;
 }
+
+// Export for testing
+export { getSnippetRegex as snippetRegex, registerSnippetDocumentLinkProvider };

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -1,6 +1,6 @@
 import * as assert from "assert";
 import * as vscode from "vscode";
-import { snippetRegex, registerSnippetCodeLensProvider } from "../extension";
+import { snippetRegex, registerSnippetDocumentLinkProvider } from "../extension";
 
 suite("snippetRegex Test Suite", () => {
   test("snippetRegex should match snippet calls", () => {
@@ -8,7 +8,7 @@ suite("snippetRegex Test Suite", () => {
     const text = `snippet('exampleSnippet',slots:true)`;
     const match = regex.exec(text);
     assert.ok(match);
-    assert.strictEqual(match[1], "exampleSnippet");
+    assert.strictEqual(match[2], "exampleSnippet"); // Snippet name is in group 2
   });
 
   test("snippetRegex should match snippet calls with slot parameter", () => {
@@ -16,7 +16,7 @@ suite("snippetRegex Test Suite", () => {
     const text = `snippet('exampleSnippet',slots:true)`;
     const match = regex.exec(text);
     assert.ok(match);
-    assert.strictEqual(match[1], "exampleSnippet");
+    assert.strictEqual(match[2], "exampleSnippet");
   });
 
   test("snippetRegex should match multiple snippet calls", () => {
@@ -24,8 +24,8 @@ suite("snippetRegex Test Suite", () => {
     const text = `snippet('firstSnippet'); snippet("secondSnippet",$data,false,true)`;
     const matches = [...text.matchAll(regex)];
     assert.strictEqual(matches.length, 2);
-    assert.strictEqual(matches[0][1], "firstSnippet");
-    assert.strictEqual(matches[1][1], "secondSnippet");
+    assert.strictEqual(matches[0][2], "firstSnippet");
+    assert.strictEqual(matches[1][2], "secondSnippet");
   });
 
   test("snippetRegex should not match invalid snippet calls", () => {
@@ -34,40 +34,190 @@ suite("snippetRegex Test Suite", () => {
     const match = regex.exec(text);
     assert.strictEqual(match, null);
   });
+
+  test("snippetRegex should capture quote characters correctly", () => {
+    const regex = snippetRegex();
+    const text1 = `snippet('singleQuote')`;
+    const text2 = `snippet("doubleQuote")`;
+    
+    const match1 = regex.exec(text1);
+    const match2 = regex.exec(text2);
+    
+    assert.ok(match1);
+    assert.ok(match2);
+    assert.strictEqual(match1[1], "'"); // Quote character is in group 1
+    assert.strictEqual(match1[2], "singleQuote"); // Snippet name is in group 2
+    assert.strictEqual(match2[1], '"');
+    assert.strictEqual(match2[2], "doubleQuote");
+  });
+
+  test("snippetRegex should handle nested quotes correctly", () => {
+    const regex = snippetRegex();
+    const text = `snippet('test-snippet', ['key' => 'value'])`;
+    const match = regex.exec(text);
+    
+    assert.ok(match);
+    assert.strictEqual(match[2], "test-snippet");
+  });
+
+  test("snippetRegex should match snippets with complex parameters", () => {
+    const regex = snippetRegex();
+    const text = `snippet("complex/path", $data, true, ['slots' => true])`;
+    const match = regex.exec(text);
+    
+    assert.ok(match);
+    assert.strictEqual(match[2], "complex/path");
+  });
 });
 
-suite("registerSnippetCodeLensProvider Test Suite", () => {
-  test("registerSnippetCodeLensProvider should provide CodeLenses for snippet calls", async () => {
+suite("registerSnippetDocumentLinkProvider Test Suite", () => {
+  test("registerSnippetDocumentLinkProvider should provide document links for snippet calls", async () => {
     const document = await vscode.workspace.openTextDocument({
       content: `snippet('exampleSnippet'); snippet("anotherSnippet")`,
       language: "php",
     });
 
-    registerSnippetCodeLensProvider();
+    registerSnippetDocumentLinkProvider();
 
-    const codeLenses = await vscode.commands.executeCommand<vscode.CodeLens[]>(
-      "vscode.executeCodeLensProvider",
+    const links = await vscode.commands.executeCommand<vscode.DocumentLink[]>(
+      "vscode.executeDocumentLinkProvider",
       document.uri
     );
 
-    assert.strictEqual(codeLenses.length, 2);
-    assert.strictEqual(codeLenses[0].command?.arguments?.[0], "exampleSnippet");
-    assert.strictEqual(codeLenses[1].command?.arguments?.[0], "anotherSnippet");
+    assert.strictEqual(links.length, 2);
+    
+    // Check that links have proper ranges and tooltips
+    assert.ok(links[0].range);
+    assert.ok(links[1].range);
+    assert.strictEqual(links[0].tooltip, "Open snippet: exampleSnippet.php");
+    assert.strictEqual(links[1].tooltip, "Open snippet: anotherSnippet.php");
   });
 
-  test("registerSnippetCodeLensProvider should not provide CodeLenses for non-snippet calls", async () => {
+  test("registerSnippetDocumentLinkProvider should not provide links for non-snippet calls", async () => {
     const document = await vscode.workspace.openTextDocument({
-      content: `echo 'Hello World';`,
+      content: `echo 'Hello World'; function test() { return 'snippet'; }`,
       language: "php",
     });
 
-    registerSnippetCodeLensProvider();
+    registerSnippetDocumentLinkProvider();
 
-    const codeLenses = await vscode.commands.executeCommand<vscode.CodeLens[]>(
-      "vscode.executeCodeLensProvider",
+    const links = await vscode.commands.executeCommand<vscode.DocumentLink[]>(
+      "vscode.executeDocumentLinkProvider",
       document.uri
     );
 
-    assert.strictEqual(codeLenses.length, 0);
+    assert.strictEqual(links.length, 0);
+  });
+
+  test("registerSnippetDocumentLinkProvider should handle complex snippet calls", async () => {
+    const document = await vscode.workspace.openTextDocument({
+      content: `snippet('complex/path', ['data' => $value], true)`,
+      language: "php",
+    });
+
+    registerSnippetDocumentLinkProvider();
+
+    const links = await vscode.commands.executeCommand<vscode.DocumentLink[]>(
+      "vscode.executeDocumentLinkProvider",
+      document.uri
+    );
+
+    assert.strictEqual(links.length, 1);
+    assert.strictEqual(links[0].tooltip, "Open snippet: complex/path.php");
+  });
+
+  test("registerSnippetDocumentLinkProvider should handle mixed quote types", async () => {
+    const document = await vscode.workspace.openTextDocument({
+      content: `snippet('single-quote'); snippet("double-quote")`,
+      language: "php",
+    });
+
+    registerSnippetDocumentLinkProvider();
+
+    const links = await vscode.commands.executeCommand<vscode.DocumentLink[]>(
+      "vscode.executeDocumentLinkProvider",
+      document.uri
+    );
+
+    assert.strictEqual(links.length, 2);
+    assert.strictEqual(links[0].tooltip, "Open snippet: single-quote.php");
+    assert.strictEqual(links[1].tooltip, "Open snippet: double-quote.php");
+  });
+
+  test("registerSnippetDocumentLinkProvider should handle snippets with whitespace", async () => {
+    const document = await vscode.workspace.openTextDocument({
+      content: `snippet(  'spaced-snippet'  )`,
+      language: "php",
+    });
+
+    registerSnippetDocumentLinkProvider();
+
+    const links = await vscode.commands.executeCommand<vscode.DocumentLink[]>(
+      "vscode.executeDocumentLinkProvider",
+      document.uri
+    );
+
+    assert.strictEqual(links.length, 1);
+    assert.strictEqual(links[0].tooltip, "Open snippet: spaced-snippet.php");
+  });
+
+  test("registerSnippetDocumentLinkProvider should create correct ranges for snippet names", async () => {
+    const content = `snippet('test-snippet')`;
+    const document = await vscode.workspace.openTextDocument({
+      content,
+      language: "php",
+    });
+
+    registerSnippetDocumentLinkProvider();
+
+    const links = await vscode.commands.executeCommand<vscode.DocumentLink[]>(
+      "vscode.executeDocumentLinkProvider",
+      document.uri
+    );
+
+    assert.strictEqual(links.length, 1);
+    
+    // Check that the range covers only the snippet name (excluding quotes)
+    const link = links[0];
+    const rangeText = document.getText(link.range);
+    assert.strictEqual(rangeText, "test-snippet");
+  });
+});
+
+suite("Edge Cases Test Suite", () => {
+  test("snippetRegex should handle empty snippet names gracefully", () => {
+    const regex = snippetRegex();
+    const text = `snippet('')`;
+    const match = regex.exec(text);
+    
+    // This should not match because our regex requires at least one character
+    assert.strictEqual(match, null);
+  });
+
+  test("snippetRegex should not match malformed snippet calls", () => {
+    const regex = snippetRegex();
+    const testCases = [
+      `snippet(test)`, // Missing quotes
+      `snippet('unclosed`,  // Unclosed quote
+      `snippet("mixed')`,   // Mixed quotes
+      `snippets('test')`,   // Wrong function name
+    ];
+    
+    testCases.forEach(testCase => {
+      const match = regex.exec(testCase);
+      assert.strictEqual(match, null, `Should not match: ${testCase}`);
+    });
+  });
+
+  test("snippetRegex should handle multiline snippet calls", () => {
+    const regex = snippetRegex();
+    const text = `snippet('test',
+      ['data' => $value],
+      true
+    )`;
+    const match = regex.exec(text);
+    
+    assert.ok(match);
+    assert.strictEqual(match[2], "test");
   });
 });


### PR DESCRIPTION
I love this extension! What do you think about replacing CodeLens with Document Links?

Current implementation:
![CleanShot 2025-05-26 at 14 51 14@2x](https://github.com/user-attachments/assets/c32bce9d-fa09-425f-b08d-294f545c8270)

Document Links:
![CleanShot 2025-05-26 at 14 50 51@2x](https://github.com/user-attachments/assets/bba37918-3ecd-4f61-a897-2c06ff5d7c82)

With document links we don't have an additional line for each snippet call, we can simply cmd click on the snippet path.